### PR TITLE
[feat] Hub - 허브가 생성 및 삭제될 때, 허브 간 이동정보도 함께 생성 및 삭제하는 기능 구현

### DIFF
--- a/com.forj.delivery-system/com.forj.hub/src/main/java/com/forj/hub/domain/service/HubService.java
+++ b/com.forj.delivery-system/com.forj.hub/src/main/java/com/forj/hub/domain/service/HubService.java
@@ -18,7 +18,6 @@ public class HubService {
 
     private final HubRepository hubRepository;
 
-    @Transactional
     public Hub createHub(String name, String roadAddress, double x, double y) {
 
         Hub hub = Hub.toHubEntity(name, roadAddress, x, y);
@@ -48,7 +47,6 @@ public class HubService {
         return hub;
     }
 
-    @Transactional
     public Boolean deleteHub(UUID hubId) {
 
         Hub hub = hubRepository.findById(hubId);

--- a/com.forj.delivery-system/com.forj.hub/src/main/java/com/forj/hub/infrastructure/repository/JPAHubMovementRepository.java
+++ b/com.forj.delivery-system/com.forj.hub/src/main/java/com/forj/hub/infrastructure/repository/JPAHubMovementRepository.java
@@ -14,5 +14,6 @@ public interface JPAHubMovementRepository extends JpaRepository<HubMovement, UUI
     @Query("SELECT h FROM HubMovement h WHERE LOWER(h.route) LIKE LOWER(CONCAT('%', :search, '%'))")
     Page<HubMovement> findAllBySearch(@Param("search") String search, Pageable pageable);
 
+    @Query("SELECT h FROM HubMovement h WHERE h.departureHubId = :departureHubId AND h.isDeleted = false")
     HubMovement findByDepartureHubId(UUID departureHubId);
 }

--- a/com.forj.delivery-system/settings.gradle
+++ b/com.forj.delivery-system/settings.gradle
@@ -4,8 +4,8 @@ include('auth',
         'delivery',
         'hub',
         'order',
-//        'server',
-//        'gateway',
+        'server',
+        'gateway',
         'company',
         'delivery-agent',
         'common',
@@ -20,8 +20,8 @@ project(':auth').projectDir = file('com.forj.auth')
 project(':delivery').projectDir = file('com.forj.delivery')
 project(':hub').projectDir = file('com.forj.hub')
 project(':order').projectDir = file('com.forj.order')
-//project(':server').projectDir = file('com.forj.server')
-//project(':gateway').projectDir = file('com.forj.gateway')
+project(':server').projectDir = file('com.forj.server')
+project(':gateway').projectDir = file('com.forj.gateway')
 project(':company').projectDir = file('com.forj.company')
 project(':delivery-agent').projectDir = file('com.forj.delivery-agent')
 project(':slack-message').projectDir = file('com.forj.slack-message')


### PR DESCRIPTION
## AS IS
허브와 허브 간 이동정보를 따로 호출해서 생성 및 삭제를 진행

## TO BE
### 허브 생성
1. 허브 생성 `POST` "/api/v1/hubs"
2. `HubApplicationService` 의 트랜잭션 시작
3. `hubService.createHub`
4. 생성된 HubId 를 `hubMovementApplicationService` 로 전달하여 허브 간 이동정보 생성
5. 단방향 순환구조의 배송 시나리오를 기반으로, 기존 허브 간 이동정보에서 가장 적절한 추가 위치를 계산
    - 새로운 허브를 삽입했을 때의 departureHub -> newHub -> arrivalHub 경로의 총 이동 시간을 계산
    - 새로운 경로의 거리 증가가 기존 경로보다 최소인 경우 해당 위치로 설정
6. 기존 허브 간 이동정보는 삭제 후 새로운 이동정보 추가
### 허브 삭제
1. 허브명으로 허브 간 이동 정보에서 데이터를 찾아서 삭제
2. 허브 삭제